### PR TITLE
Add React Native Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ _[XCode]()_
 
   - `$ git clone git@github.com:reallynotburner/rn_web_monorepo.git`
   - `$ cd rn_web_monorepo`
-  - `$ yarn && yarn pods`
+  - `$ yarn`
 
 To see your app running in iOS and Android:
   - `$ yarn mobile`
@@ -29,8 +29,8 @@ To see you app running in Web
 
 Your web app is served on [localhost:3000](http://localhost:3000).
 
-Also consider [Ben Awad's Tutorial on Youtube](https://www.youtube.com/watch?v=J0b11tvEkFQ&t=3s), his focus being React Hooks and Typescript.
-
 See [ReNative](https://renative.org/) which has excellent CLI's to build projects across many other platforms, again, with much code reuse.
 
-Also see [Expo CLI](https://expo.io/) which has a lot of built-in support for the mono-repo approach, including extremely valuable push notification, and on-air updating for the mobile targets.
+See [Expo CLI](https://expo.io/) which has a lot of built-in support for the mono-repo approach, including extremely valuable push notification, and on-air updating for the mobile targets.
+
+Also consider [Ben Awad's Tutorial on Youtube](https://www.youtube.com/watch?v=J0b11tvEkFQ&t=3s), his focus being React Hooks and Typescript.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "workspaces": {
     "packages": [
       "packages/*"
-    ]
+    ],
+    "nohoist": ["**/react-native-video", "**/react-native-video/**"]
   },
   "scripts": {
     "android": "yarn workspace mobile android",
@@ -18,6 +19,7 @@
     "clean-ios": "rm -rf packages/mobile/ios/Pods",
     "clean": "yarn clean-node && yarn clean-ios",
     "pods": "(cd ./packages/mobile/ios && pod install)",
+    "postinstall": "yarn pods",
     "web": "yarn workspace web start"
   },
   "dependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,5 +1,11 @@
 {
   "name": "components",
   "version": "0.0.1",
-  "private": true
+  "private": true,
+  "dependencies": {
+    "@types/react-native-video": "^3.1.5",
+    "react-native-video": "5.0.0"
+  },
+  "devDependencies": {
+  }
 }

--- a/packages/components/src/App.tsx
+++ b/packages/components/src/App.tsx
@@ -1,14 +1,6 @@
 import React from 'react';
-import {
-  SafeAreaView,
-  ScrollView,
-  StatusBar,
-  StyleSheet,
-  Text,
-  View,
-} from 'react-native';
-
-import { AppHeader } from './AppHeader'
+import { SafeAreaView, ScrollView, StatusBar, StyleSheet, Text, View } from 'react-native';
+import Player from './Player';
 
 export function App() {
   return (
@@ -18,35 +10,12 @@ export function App() {
         <ScrollView
           contentInsetAdjustmentBehavior="automatic"
           style={styles.scrollView}>
-          <AppHeader />
           {global.HermesInternal == null ? null : (
             <View style={styles.engine}>
               <Text style={styles.footer}>Engine: Hermes</Text>
             </View>
           )}
-          <View style={styles.body}>
-            <View style={styles.sectionContainer}>
-              <Text style={styles.sectionTitle}>Code sharing using Monorepo</Text>
-              <Text style={styles.sectionDescription}>
-                Edit <Text style={styles.highlight}>packages/components/App.tsx</Text> to change this
-                screen and then come back to see your edits (in the phone or the browser).
-              </Text>
-            </View>
-            <View style={styles.sectionContainer}>
-              <Text style={styles.sectionTitle}>Web support via react-native-web</Text>
-              <Text style={styles.sectionDescription}>
-                Run <Text style={styles.highlight}>yarn workspace web start</Text> to 
-                open this app in the browser. 
-              </Text>
-              <Text style={styles.sectionDescription}>
-                It will share the same code from mobile, unless you create platform-specific files 
-                using the <Text style={styles.highlight}>.web.tsx</Text> extension 
-                (also supports <Text style={styles.highlight}>.android</Text>,{' '}
-                <Text style={styles.highlight}>.ios</Text>,{' '}
-                <Text style={styles.highlight}>.native</Text>, etc).
-              </Text>
-            </View>
-          </View>
+          <Player style={styles.player}></Player>
         </ScrollView>
       </SafeAreaView>
     </>
@@ -54,6 +23,11 @@ export function App() {
 };
 
 const styles = StyleSheet.create({
+  player: {
+    width: 400,
+    height: 250,
+    backgroundColor: 'pink'
+  },
   scrollView: {
     backgroundColor: 'white',
   },

--- a/packages/components/src/Player.tsx
+++ b/packages/components/src/Player.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Video from 'react-native-video';
+
+
+const Player: Function = (props: any) => {
+  return (
+    <Video
+      source={{
+        uri: 'https://lsqvc1us-lh.akamaihd.net/i/lsqvc1us_01@809353/master.m3u8'
+      }}
+      
+      style={props.style}
+    />
+  );
+};
+
+export default Player;

--- a/packages/mobile/ios/Podfile
+++ b/packages/mobile/ios/Podfile
@@ -34,6 +34,8 @@ target 'rn_web_monorepo' do
   pod 'glog', :podspec => '../../../node_modules/react-native/third-party-podspecs/glog.podspec'
   pod 'Folly', :podspec => '../../../node_modules/react-native/third-party-podspecs/Folly.podspec'
 
+  pod 'react-native-video', :path => '../node_modules/react-native-video'
+
   target 'rn_web_monorepoTests' do
     inherit! :search_paths
     # Pods for testing

--- a/packages/mobile/ios/Podfile.lock
+++ b/packages/mobile/ios/Podfile.lock
@@ -182,6 +182,11 @@ PODS:
     - React-cxxreact (= 0.61.3)
     - React-jsi (= 0.61.3)
   - React-jsinspector (0.61.3)
+  - react-native-video (5.0.0):
+    - React
+    - react-native-video/Video (= 5.0.0)
+  - react-native-video/Video (5.0.0):
+    - React
   - React-RCTActionSheet (0.61.3):
     - React-Core/RCTActionSheetHeaders (= 0.61.3)
   - React-RCTAnimation (0.61.3):
@@ -236,6 +241,7 @@ DEPENDENCIES:
   - React-jsi (from `../../../node_modules/react-native/ReactCommon/jsi`)
   - React-jsiexecutor (from `../../../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../../../node_modules/react-native/ReactCommon/jsinspector`)
+  - react-native-video (from `../node_modules/react-native-video`)
   - React-RCTActionSheet (from `../../../node_modules/react-native/Libraries/ActionSheetIOS`)
   - React-RCTAnimation (from `../../../node_modules/react-native/Libraries/NativeAnimation`)
   - React-RCTBlob (from `../../../node_modules/react-native/Libraries/Blob`)
@@ -282,6 +288,8 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native/ReactCommon/jsiexecutor"
   React-jsinspector:
     :path: "../../../node_modules/react-native/ReactCommon/jsinspector"
+  react-native-video:
+    :path: "../node_modules/react-native-video"
   React-RCTActionSheet:
     :path: "../../../node_modules/react-native/Libraries/ActionSheetIOS"
   React-RCTAnimation:
@@ -321,6 +329,7 @@ SPEC CHECKSUMS:
   React-jsi: 8bcf5836caa8a759c135ab9ef97f3e023a7b94af
   React-jsiexecutor: ae078e9df9c65bcdcf68f9a17656657932d95528
   React-jsinspector: a8939cc6909607eb5e8a5ecfff7c6226984e174d
+  react-native-video: 6555881252c8ca039760e1cd6df28ac28ffb2baf
   React-RCTActionSheet: 94671eef55b01a93be735605822ef712d5ea208e
   React-RCTAnimation: 524ae33e73de9c0fe6501a7a4bda8e01d26499d9
   React-RCTBlob: 5481c2db702f57207af7e7a9b32d90524b821b72
@@ -333,6 +342,6 @@ SPEC CHECKSUMS:
   ReactCommon: c2c63d9290b422ca6ad5b3663073a015dd892ae9
   Yoga: 02036f6383c0008edb7ef0773a0e6beb6ce82bd1
 
-PODFILE CHECKSUM: a89024dcdb087bb5f37ed2f1ff206d11f7e47804
+PODFILE CHECKSUM: 2956d38019937fb88a1facaf057f6eb858d2720f
 
 COCOAPODS: 1.8.4

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -14,9 +14,11 @@
     "xcode": "open ios/rn_web_monorepo.xcworkspace"
   },
   "dependencies": {
+    "@types/react-native-video": "^3.1.5",
     "components": "0.0.1",
     "react": "16.11.0",
-    "react-native": "0.61.3"
+    "react-native": "0.61.3",
+    "react-native-video": "5.0.0"
   },
   "devDependencies": {
     "@react-native-community/eslint-config": "0.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1522,6 +1522,22 @@
   resolved "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
 
+"@types/react-native-video@^3.1.5":
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/@types/react-native-video/-/react-native-video-3.1.5.tgz#3617e7e96bd1cffb62e755c8b24fdd33329c843e"
+  integrity sha512-5EvRot5MEEOQroB9XSJsTaYIW1UKiAeDDJfXLNo9Q0AClRwFV4ugYYBTsKoomNUYPZycfJhrvmUbHXb4Vx8oOA==
+  dependencies:
+    "@types/react" "*"
+    "@types/react-native" "*"
+
+"@types/react-native@*":
+  version "0.60.25"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.60.25.tgz#65cb0bf5dd0631079215b63525458e4123c1c90e"
+  integrity sha512-827dIVvSTxSH5uTpsJJH7O4wpRuw0rm3yIzRL3a2yKawA0nyhgC1GPKTXHFIn2GfSdXn1Gty2dJ+k6uDZF3MWQ==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/react" "*"
+
 "@types/react-native@0.60.22":
   version "0.60.22"
   resolved "https://registry.npmjs.org/@types/react-native/-/react-native-0.60.22.tgz#ba199a441cb0612514244ffb1d0fe6f04c878575"
@@ -4007,6 +4023,11 @@ elliptic@^6.0.0:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
+
+eme-encryption-scheme-polyfill@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/eme-encryption-scheme-polyfill/-/eme-encryption-scheme-polyfill-1.0.3.tgz#6ee8d9633bfa5ab44a620ea33854f4e7aa58f3c2"
+  integrity sha512-BO98g91VkDSpFHHgWAeppz9hn1U3WRQWKh4O3mZk5JvaUvgYm0Q67t7/bC+8iEQsK+JA/K7+v2lhz1B+zXR/zA==
 
 emoji-regex@^7.0.1, emoji-regex@^7.0.2:
   version "7.0.3"
@@ -6687,6 +6708,11 @@ jsx-ast-utils@^2.0.1, jsx-ast-utils@^2.1.0, jsx-ast-utils@^2.2.1:
     array-includes "^3.0.3"
     object.assign "^4.1.0"
 
+keymirror@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/keymirror/-/keymirror-0.1.1.tgz#918889ea13f8d0a42e7c557250eee713adc95c35"
+  integrity sha1-kYiJ6hP40KQufFVyUO7nE63JXDU=
+
 killable@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz#4c8ce441187a061c7474fb87ca08e2a638194892"
@@ -9133,7 +9159,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.3"
 
-prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -9383,6 +9409,15 @@ react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   version "16.11.0"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.11.0.tgz#b85dfecd48ad1ce469ff558a882ca8e8313928fa"
   integrity sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw==
+
+react-native-video@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-video/-/react-native-video-5.0.0.tgz#30b58e31f0776bfa8dc71109c25114d4e50d9209"
+  integrity sha512-nSG7Zkc0SE2Pa/sKWvMEPUc9Zlo0iVOFTac0GcXd/U5vTsm4L28leQzJ8K/s+Yc5xfCYaeb9bIWROqw2oiB9Ig==
+  dependencies:
+    keymirror "^0.1.1"
+    prop-types "^15.5.10"
+    shaka-player "^2.4.4"
 
 react-native-web@0.11.7:
   version "0.11.7"
@@ -10168,6 +10203,13 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+shaka-player@^2.4.4:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-2.5.7.tgz#d8cf3489fef2609957ae44a4faa46a38a5fcda20"
+  integrity sha512-Hcanwr1cnGru1E42EXml6XaoRCByutr3DRI9LRoknZKdIlsBG+F4kT5aWrMlwFw6foFNw9hoMpRsB6LWUPlrIw==
+  dependencies:
+    eme-encryption-scheme-polyfill "^1.0.2"
 
 shallow-clone@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
No Ticket

Adding React Native Video to the project to test difficulty with using the monorepo.
- If the common directory and mobile directory have dependency that can't deal with Yarn workspaces, you have to add them to the package.jsons' of common and mobile, then nohoist them in the root package.json.
- React Native Web is that kind of dependency.  Get's weird errors where RCTVideo isn't defined, etc.. unless we No Hoist.